### PR TITLE
always allow wp/v2/media/:id rest-api calls

### DIFF
--- a/wp-content/themes/POFAPIWP/functions.php
+++ b/wp-content/themes/POFAPIWP/functions.php
@@ -352,6 +352,18 @@ if (!class_exists("POFTREE\\program")) {
 
 }
 
+/**
+ * Remove /wp/v2/media/:id permission check
+ */
+add_filter( 'rest_endpoints', function( array $endpoints ) {
+    foreach ( $endpoints['/wp/v2/media/(?P<id>[\d]+)'] as &$endpoint ) {
+        if ( $endpoint['methods'] === 'GET' && in_array( 'get_item', $endpoint['callback'] ) ) {
+            unset( $endpoint['permission_callback'] );
+        }
+    }
+    return $endpoints;
+});
+
 // Always redirect a user to the home_url() upon successful password reset
 add_filter( 'lostpassword_redirect', 'my_redirect_home' );
 function my_redirect_home( $lostpassword_redirect ) {


### PR DESCRIPTION
This fixes a problem which happens when a media item is added to an unpublished post and this causes it to be unavailable via the rest-api.
more info on the problem: https://github.com/WP-API/WP-API/issues/2596